### PR TITLE
Update version numbers, v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.1.0] - 2025-06-13
+
 ### Added
 
 - Sortables (e.g. endpoint `GET /sortables`)
@@ -223,7 +225,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 See the [stac-spec CHANGELOG](https://github.com/radiantearth/stac-spec/blob/v0.9.0/CHANGELOG.md)
 for STAC API releases prior to or equal to version 0.9.0.
 
-[Unreleased]: <https://github.com/stac-api-extensions/sort/compare/v1.0.0..main>
+[Unreleased]: <https://github.com/stac-api-extensions/sort/compare/v1.1.0..main>
+[v1.1.0]: <https://github.com/stac-api-extensions/sort/tree/v1.1.0>
 [v1.0.0]: <https://github.com/stac-api-extensions/sort/tree/v1.0.0>
 [v1.0.0-rc.2]: <https://github.com/stac-api-extensions/sort/tree/v1.0.0-rc.2>
 [v1.0.0-rc.1]: <https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-rc.1>

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 - **Title:** Sort
 - **OpenAPI specification:** [openapi.yaml](openapi.yaml)
 - **Conformance Classes:**
-  - **STAC API - Item Search** binding: <https://api.stacspec.org/v1.0.0/item-search#sort>
-  - **STAC API - Features** binding: <https://api.stacspec.org/v1.0.0/ogcapi-features#sort>
-  - **STAC API - Collection Search** binding: <https://api.stacspec.org/v1.0.0-rc.1/collection-search#sort>
+  - **STAC API - Item Search** binding: <https://api.stacspec.org/v1.1.0/item-search#sort>
+  - **STAC API - Features** binding: <https://api.stacspec.org/v1.1.0/ogcapi-features#sort>
+  - **STAC API - Collection Search** binding: <https://api.stacspec.org/v1.1.0/collection-search#sort>
 - **Scope:** STAC API - Features, STAC API - Item Search, STAC API - Collection Search
 - **[Extension Maturity Classification](https://github.com/radiantearth/stac-api-spec/tree/main/README.md#maturity-classification):** Stable
 - **Dependencies:**
@@ -126,9 +126,9 @@ All Sortables endpoints SHALL be referenced with a link with the link relation t
 
 | Sortables Endpoint                                          | Endpoint linking to the Sortables Endpoint | Conformance class                                                  | Applicable `sortby` endpoints           |
 | ----------------------------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------ | --------------------------------------- |
-| `GET /sortables`                                            | `GET /`                                    | `https://api.stacspec.org/v1.0.0/item-search#sortables`            | `GET /search` and `POST /search`        |
+| `GET /sortables`                                            | `GET /`                                    | `https://api.stacspec.org/v1.1.0/item-search#sortables`             | `GET /search` and `POST /search`        |
 | `GET /collections/{collectionId}/sortables`                 | `GET /collections/{collectionId}`          | `http://www.opengis.net/spec/ogcapi-features-5/1.0/conf/sortables` | `GET /collections/{collectionId}/items` |
-| `GET /...` (*Endpoint name to be chosen by implementation*) | `GET /collections`                         | `https://api.stacspec.org/v1.0.0-rc.1/collection-search#sortables` | `GET /collections/{collectionId}/items` |
+| `GET /...` (*Endpoint name to be chosen by implementation*) | `GET /collections`                         | `https://api.stacspec.org/v1.1.0/collection-search#sortables`       | `GET /collections/{collectionId}/items` |
 
 An example for a link to the sortables endpoint could be:
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: The SpatioTemporal Asset Catalog API - Sort
   description: Adds Parameter to control sorting of returns results.
-  version: 1.0.0
+  version: 1.1.0
   contact:
     name: STAC Specification
     url: 'http://stacspec.org'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "stac-api-sort-extension-spec",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "stac-api-sort-extension-spec",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@stoplight/spectral-cli": "^6.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "stac-api-sort-extension-spec",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "STAC API helpers to check the API spec.",
     "repository": "https://github.com/stac-api-extensions/sort",
     "license": "Apache-2.0",


### PR DESCRIPTION
**Proposed Changes:**

1. Update version numbers
2. Release v1.1.0

Note: There's some weirdness goind on with the version numbers, e.g. for collection-search the version numbers came from the collection search extension, while now I've updated them to follow the versioning of the sort extension, jumping from 1.0.0-rc.1 to 1.1.0 (without a 1.0.0). Similarly, sortables use the version number of OGC API Features right now.

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
